### PR TITLE
fix: filter Facebook In-App Browser native bridge errors (BABYPEEK-4, BABYPEEK-5)

### DIFF
--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -52,6 +52,13 @@ export function initSentry() {
       "Non-Error promise rejection captured",
       // Facebook In-App Browser injects scripts that throw regex errors
       "Invalid regular expression",
+      // Facebook In-App Browser native bridge errors (BABYPEEK-4, BABYPEEK-5)
+      // Android: Facebook's injected JS fails to invoke Java bridge postMessage
+      /Java bridge method invocation error/,
+      // iOS: Facebook's injected JS tries to access webkit.messageHandlers that don't exist
+      /evaluating 'window\.webkit\.messageHandlers\[.*\]\.postMessage'/,
+      // Generic postMessage bridge failures from in-app browsers
+      /Error invoking postMessage/,
       // Common third-party script errors
       "fb_xd_fragment",
       "instantSearchSDKJSBridgeClearHighlight",


### PR DESCRIPTION
## Summary

Both BABYPEEK-4 and BABYPEEK-5 are **noise from Facebook's In-App Browser**, not BabyPeek bugs.

### BABYPEEK-4 — Android Java Bridge Error
- **Error:** `Error invoking postMessage: Java bridge method invocation error`
- **Browser:** Facebook 547.0.0 on Android 16 (Samsung SM-A356E)
- **Cause:** Facebook injects its own JavaScript into the WebView that tries to use a Java bridge (`postMessage`) which fails. This is Facebook's code, not ours.

### BABYPEEK-5 — iOS WebKit messageHandlers Crash  
- **Error:** `TypeError: undefined is not an object (evaluating 'window.webkit.messageHandlers[e].postMessage')`
- **Browser:** Facebook 547.1.0 on iOS 26.2 (iPhone 13)
- **Cause:** Facebook injects JavaScript that tries to access `window.webkit.messageHandlers` — a WKWebView API that isn't available in their own in-app browser context. Again, Facebook's code.

### Fix
Added three `ignoreErrors` regex patterns to the Sentry config:
- `/Java bridge method invocation error/` — catches Android bridge failures
- `/evaluating 'window\.webkit\.messageHandlers\[.*\]\.postMessage'/` — catches iOS bridge failures  
- `/Error invoking postMessage/` — catches generic postMessage bridge errors

### Related
- Similar to the previous fix (commit 3e6c920) that added filters for Facebook regex errors
- Related to BABYPEEK-2 (Java object gone)

Sentry links:
- [BABYPEEK-4](https://ac-tech-labz.sentry.io/issues/7253454653/)
- [BABYPEEK-5](https://ac-tech-labz.sentry.io/issues/7253895641/)